### PR TITLE
fix(sass): remove query params when resolving virtual sass modules

### DIFF
--- a/src/utils/configure-vite.ts
+++ b/src/utils/configure-vite.ts
@@ -50,15 +50,10 @@ export function configureVite(configKey: string, nuxt: Nuxt, ctx: VuetifyNuxtCon
       if (enableModernSassCompiler) {
         const sassEmbedded = isPackageExists('sass-embedded')
         if (sassEmbedded) {
-          // vite version >= 5.4.2
-          // check https://github.com/vitejs/vite/pull/17754 and https://github.com/vitejs/vite/pull/17728
-          const omit = major > 5 || (major === 5 && minor > 4) || (major === 5 && minor === 4 && patch >= 2)
-          if (!omit) {
-            viteInlineConfig.css ??= {}
-            viteInlineConfig.css.preprocessorOptions ??= {}
-            viteInlineConfig.css.preprocessorOptions.sass ??= {}
-            viteInlineConfig.css.preprocessorOptions.sass.api = 'modern-compiler'
-          }
+          viteInlineConfig.css ??= {}
+          viteInlineConfig.css.preprocessorOptions ??= {}
+          viteInlineConfig.css.preprocessorOptions.sass ??= {}
+          viteInlineConfig.css.preprocessorOptions.sass.api = 'modern-compiler'
         }
         else {
           viteInlineConfig.css ??= {}

--- a/src/vite/vuetify-styles-plugin.ts
+++ b/src/vite/vuetify-styles-plugin.ts
@@ -48,8 +48,13 @@ export function vuetifyStylesPlugin(
       }
     },
     async resolveId(source, importer, { custom, ssr }) {
-      if (source.startsWith(PREFIX) || source.startsWith(SSR_PREFIX))
-        return source
+      if (source.startsWith(PREFIX) || source.startsWith(SSR_PREFIX)) {
+        if (source.endsWith('.sass'))
+          return source
+
+        const idx = source.indexOf('?')
+        return idx > -1 ? source.slice(0, idx) : source
+      }
 
       if (
         source === 'vuetify/styles' || (


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->
Vite and or Nuxt adding some query params, removing them when resolving the virtual sass file seems to fix the problem.

If the problem still present, we'll need to generate temporary virtual SASS files (tested and working here https://github.com/userquin/nuxt3-vuetify3-issue-15412/pull/2).

### Linked Issues

<!-- e.g. fixes #123 -->
related , check comment here https://github.com/vuetifyjs/nuxt-module/issues/150#issuecomment-2349146371

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
