### PR TITLE
fix(styles): resolve new scss component styles

### DIFF
--- a/src/utils/configure-vite.ts
+++ b/src/utils/configure-vite.ts
@@ -54,12 +54,16 @@ export function configureVite(configKey: string, nuxt: Nuxt, ctx: VuetifyNuxtCon
           viteInlineConfig.css.preprocessorOptions ??= {}
           viteInlineConfig.css.preprocessorOptions.sass ??= {}
           viteInlineConfig.css.preprocessorOptions.sass.api = 'modern-compiler'
+          viteInlineConfig.css.preprocessorOptions.scss ??= {}
+          viteInlineConfig.css.preprocessorOptions.scss.api = 'modern-compiler'
         }
         else {
           viteInlineConfig.css ??= {}
           viteInlineConfig.css.preprocessorOptions ??= {}
           viteInlineConfig.css.preprocessorOptions.sass ??= {}
           viteInlineConfig.css.preprocessorOptions.sass.api = 'modern'
+          viteInlineConfig.css.preprocessorOptions.scss ??= {}
+          viteInlineConfig.css.preprocessorOptions.scss.api = 'modern'
           if (!('preprocessorMaxWorkers' in viteInlineConfig.css))
             viteInlineConfig.css.preprocessorMaxWorkers = true
         }


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->
We have new components using scss instead sass, we need to do an extra fs check.

This PR also includes the Vite configuration for scss to use the new  `modern-compiler/modern` sass-embeded apis.

### Linked Issues

<!-- e.g. fixes #123 -->
fix #304

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->
Only tested with Nuxt 3.15.4, Nuxt 3.16.0 and Nuxt 3.16.2.


---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
