### PR TITLE
feat(labs): enable labs components auto-import by default

### DIFF
--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -15,6 +15,10 @@ This PR [fix(nuxt): support serialising rich server logs](https://github.com/nux
 
 ## Vuetify styles broken with Nuxt 3.16.0
 
+::: info
+Fixed in Vuetify version `v3.8.0` (Andromeda)
+:::
+
 If your Vuetify styles not being applied when using Nuxt 3.16.0, you can drop this module to your modules folder:
 
 ```ts

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -16,7 +16,7 @@ This PR [fix(nuxt): support serialising rich server logs](https://github.com/nux
 ## Vuetify styles broken with Nuxt 3.16.0
 
 ::: info
-Fixed in Vuetify version `v3.8.0` (Andromeda)
+Fixed in Vuetify version `v3.8.0` (Andromeda).
 :::
 
 If your Vuetify styles not being applied when using Nuxt 3.16.0, you can drop this module to your modules folder:

--- a/docs/guide/globals/index.md
+++ b/docs/guide/globals/index.md
@@ -5,6 +5,7 @@ The module will enable automatic tree shaking for Vuetify components.
 You don't need to install any Vuetify Vite Plugin (the module will throw an error if any Vuetify Vite Plugin is installed in your Nuxt configuration):
 - the module will provide auto-import support via `vuetify/dist/json/importMap.json` json file and Nuxt `components:extend` hook.
 - the module will register a custom Vite Plugin for Vuetify styles: it is just a copy from the original Vuetify Vite Styles Plugin, changing some virtual names mappings and handling SSR flags.
+- from version `v0.18.6`, the module supports [Component Labs](https://vuetifyjs.com/en/labs/introduction/) auto-import.
 
 You can register the following Vuetify components globally:
 - [Global Components](/guide/globals/global-components)

--- a/docs/guide/globals/lab-components.md
+++ b/docs/guide/globals/lab-components.md
@@ -4,6 +4,10 @@ outline: deep
 
 # Lab Components
 
+::: info
+From version `v0.18.6`, the module supports [labs components](https://vuetifyjs.com/en/labs/introduction/) auto-import, you can use them on demand.
+:::
+
 The module provides support to use Vuetify [labs components](https://vuetifyjs.com/en/labs/introduction/) via `vuetifyOptions.labsComponents` module option, it has been declared properly to have better DX.
 
 You can register all the lab components or only the ones you need: check the [lab component definition](https://github.com/vuetifyjs/nuxt-module/blob/main/src/types.ts#L140-L141).

--- a/src/utils/configure-vite.ts
+++ b/src/utils/configure-vite.ts
@@ -1,6 +1,6 @@
 import type { Nuxt } from '@nuxt/schema'
 import defu from 'defu'
-import type { Options } from '@vuetify/loader-shared'
+import type { ObjectImportPluginOptions } from '@vuetify/loader-shared'
 import { isPackageExists } from 'local-pkg'
 import { vuetifyStylesPlugin } from '../vite/vuetify-styles-plugin'
 import { vuetifyConfigurationPlugin } from '../vite/vuetify-configuration-plugin'
@@ -70,17 +70,16 @@ export function configureVite(configKey: string, nuxt: Nuxt, ctx: VuetifyNuxtCon
       }
     }
 
-    // fix #236
-    const vuetifyImportOptions: Options = {}
+    const autoImport: ObjectImportPluginOptions = { labs: true }
     const ignoreDirectives = ctx.moduleOptions.ignoreDirectives
+    // fix #236
     if (ignoreDirectives) {
-      const ignore = Array.isArray(ignoreDirectives)
+      autoImport.ignore = Array.isArray(ignoreDirectives)
         ? ignoreDirectives
         : [ignoreDirectives]
-      vuetifyImportOptions.autoImport = { ignore }
     }
 
-    viteInlineConfig.plugins.push(vuetifyImportPlugin(vuetifyImportOptions))
+    viteInlineConfig.plugins.push(vuetifyImportPlugin({ autoImport }))
     // exclude styles plugin
     if (typeof ctx.moduleOptions.styles !== 'boolean')
       viteInlineConfig.plugins.push(vuetifyStylesPlugin({ styles: ctx.moduleOptions.styles }, ctx.viteVersion, ctx.logger))


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->
Right now there is no way to use component labs if not registering them globally, this PR enables component labs auto-import by default.

### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
