### PR TITLE
fix: update `isNuxtGenerate` flag to use `nitro.static`

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -98,7 +98,7 @@ export default defineNuxtModule<ModuleOptions>({
       vuetifyFilesToWatch: [],
       isSSR: nuxt.options.ssr,
       isDev: nuxt.options.dev,
-      isNuxtGenerate: nuxt.options._generate,
+      isNuxtGenerate: nuxt.options.nitro.static || (nuxt.options as any)._generate /* TODO: remove in future */,
       unocss: hasNuxtModule('@unocss/nuxt', nuxt),
       i18n: hasNuxtModule('@nuxtjs/i18n', nuxt),
       icons: undefined!,

--- a/src/module.ts
+++ b/src/module.ts
@@ -98,7 +98,7 @@ export default defineNuxtModule<ModuleOptions>({
       vuetifyFilesToWatch: [],
       isSSR: nuxt.options.ssr,
       isDev: nuxt.options.dev,
-      isNuxtGenerate: nuxt.options.nitro.static || (nuxt.options as any)._generate /* TODO: remove in future */,
+      isNuxtGenerate: !!nuxt.options.nitro.static,
       unocss: hasNuxtModule('@unocss/nuxt', nuxt),
       i18n: hasNuxtModule('@nuxtjs/i18n', nuxt),
       icons: undefined!,


### PR DESCRIPTION
### Description


Since nuxi v3.8, we've supported setting `nuxt.options.nitro.static` instead of `nuxt.options._generate` (which is an internal flag) - see https://github.com/nuxt/nuxt/pull/21860.

Now, in preparation for Nuxt v4, we've removed the types for `_generate` (see https://github.com/nuxt/nuxt/pull/32355). This PR adds support for new version in backwards compatible way (ignoring type issues) - I'd suggest you remove support in a future major.

### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
