### PR TITLE
fix(styles): inline establishing cascade-layer order for Vuetify 4 (#381)

### DIFF
--- a/docs/guide/styling/common-setup.md
+++ b/docs/guide/styling/common-setup.md
@@ -66,3 +66,77 @@ export default defineNuxtConfig({
 ```
 
 When using `configFile`, you can also enable [Experimental Caching](/guide/styling/caching) to improve build performance.
+
+### Cascade Layers
+
+Vuetify 4 organizes its styles with [CSS cascade layers](https://developer.mozilla.org/en-US/docs/Web/CSS/@layer). Because component styles are injected on demand, their relative order — and therefore layer priority — would otherwise depend on injection order, which is non-deterministic in dev and chunk-dependent in production. This can let Vuetify's reset outrank component rules (for example a `<v-btn size="small">` rendering at the wrong font size).
+
+To make it deterministic, the module inlines the establishing layer order into the SSR'd `<head>` before any component style is parsed. This happens automatically on **Vuetify 4** and needs no configuration.
+
+The default order is:
+
+```css
+@layer vuetify-core, vuetify-components, vuetify-overrides, vuetify-utilities, vuetify-final;
+```
+
+::: info
+This applies to **Vuetify 4** only and is skipped when `styles` is `'none'`. Vuetify 3's layers are opt-in, use different names, and live under a single top-level `vuetify` layer.
+:::
+
+#### Custom order
+
+A flat `@layer` statement freezes the listed layers contiguously, so a layer you declare later can only be appended after them. If you need your own layer to sit **between** Vuetify's layers, provide the full order via `cascadeLayers`. Known Vuetify layer names are offered as autocomplete suggestions, and any custom name is allowed.
+
+```ts
+export default defineNuxtConfig({
+  modules: ['vuetify-nuxt-module'],
+  vuetify: {
+    moduleOptions: {
+      cascadeLayers: [
+        'vuetify-core',
+        'vuetify-components',
+        'my-overrides', // beats components, loses to vuetify-overrides
+        'vuetify-overrides',
+        'vuetify-utilities',
+        'vuetify-final'
+      ]
+    }
+  }
+})
+```
+
+Your list should include Vuetify's layers, otherwise the ordering guarantee is lost for any omitted layer.
+
+#### Opt out
+
+Set `cascadeLayers` to `false` to inject nothing and manage the cascade-layer order yourself.
+
+```ts
+export default defineNuxtConfig({
+  modules: ['vuetify-nuxt-module'],
+  vuetify: {
+    moduleOptions: {
+      cascadeLayers: false
+    }
+  }
+})
+```
+
+#### Migrating from a manual workaround
+
+Earlier versions had no fix for the layer-order race, so a common workaround was to declare the layer order yourself — typically an inline head style:
+
+```ts
+// no longer needed
+app: {
+  head: {
+    style: [{
+      innerHTML: '@layer vuetify-core,vuetify-components,vuetify-overrides,vuetify-utilities,vuetify-final;',
+      tagPriority: -100
+    }]
+  }
+}
+```
+
+- **If your workaround used the default order** (as above), you can simply **remove it** — the module now injects the same statement. Leaving it in place is harmless (re-declaring the same order is a no-op), just redundant.
+- **If your workaround declared a custom order** to slot your own layer between Vuetify's — especially via a `css: ['~/layers.css']` file or a `@layer` line in your `configFile` SCSS — move that order to [`cascadeLayers`](#custom-order). Otherwise the module's default statement, parsed first, establishes Vuetify's layers contiguously and your custom layer can only end up after them. Alternatively, set `cascadeLayers: false` to keep your own workaround authoritative.

--- a/packages/vuetify-nuxt-module/src/types.ts
+++ b/packages/vuetify-nuxt-module/src/types.ts
@@ -146,6 +146,20 @@ export type LabComponentName = keyof typeof import('vuetify/labs/components')
 export type LabComponents = boolean | LabComponentName | LabComponentName[]
 export type VuetifyLocale = keyof typeof import('vuetify/locale')
 
+/**
+ * A CSS cascade-layer name for `cascadeLayers`. Vuetify 4's built-in layer
+ * names are suggested for autocomplete, while any custom layer name is allowed.
+ */
+export type VuetifyCascadeLayer
+  = | 'vuetify-core'
+    | 'vuetify-components'
+    | 'vuetify-overrides'
+    | 'vuetify-utilities'
+    | 'vuetify-final'
+    // `string & {}` keeps the literal suggestions above for autocomplete while
+    // still allowing arbitrary custom layer names.
+    | (string & {})
+
 export interface VOptions extends Partial<Omit<VuetifyOptions, | 'ssr' | 'aliases' | 'components' | 'directives' | 'locale' | 'date' | 'icons'>> {
   /**
    * Configure the SSR options.
@@ -289,6 +303,33 @@ export interface MOptions {
      */
     utilities?: boolean
   }
+  /**
+   * Establishing CSS cascade-layer order, inlined into the SSR'd `<head>`.
+   *
+   * In treeshaking modes Vuetify's per-component styles are injected on demand,
+   * each carrying its own `@layer vuetify-components { … }` block. Their order
+   * is otherwise decided by injection sequence (non-deterministic in dev, chunk
+   * order in prod), which can let `vuetify-core.reset` outrank component rules
+   * (e.g. `<v-btn size="small">` renders at the wrong font-size). Declaring the
+   * layer order once, before any component style is parsed, makes it
+   * deterministic. See https://github.com/vuetifyjs/nuxt-module/issues/381.
+   *
+   * - **omit** (default) — inject Vuetify's order:
+   *   `vuetify-core, vuetify-components, vuetify-overrides, vuetify-utilities, vuetify-final`.
+   * - **`string[]`** — inject your own order, e.g. to slot a custom layer
+   *   between Vuetify's (a flat `@layer` statement freezes the named layers
+   *   contiguously, so a later-declared new layer can only append). Your list
+   *   should include Vuetify's layers, or the race it fixes can reappear for
+   *   any omitted layer.
+   * - **`false`** — inject nothing; manage the cascade-layer order yourself.
+   *
+   * Vuetify 4 only — ignored on Vuetify 3 (layers are opt-in there, use
+   * different names, and live under a single top-level `vuetify` layer) and
+   * when `styles` is `'none'`.
+   *
+   * @since v1.0.0
+   */
+  cascadeLayers?: VuetifyCascadeLayer[] | false
   /**
    * Disable the modern SASS compiler and API.
    *

--- a/packages/vuetify-nuxt-module/src/utils/configure-nuxt.ts
+++ b/packages/vuetify-nuxt-module/src/utils/configure-nuxt.ts
@@ -3,7 +3,7 @@ import type { VuetifyNuxtContext } from './config'
 import { addImports, addPlugin, addTemplate, extendWebpackConfig, isNuxtMajorVersion, resolvePath } from '@nuxt/kit'
 import { RESOLVED_VIRTUAL_MODULES } from '../vite/constants'
 import { toKebabCase } from './index'
-import { resolveVuetifyConfigFile } from './styles'
+import { applyCascadeLayersHeadStyle, resolveVuetifyConfigFile } from './styles'
 import { addVuetifyNuxtPlugins } from './vuetify-nuxt-plugins'
 
 export function getTemplate (source: string, settings: string | null): string {
@@ -54,6 +54,12 @@ export async function configureNuxt (
       nuxt.options.css.push(await resolvePath('vuetify/styles'))
     }
   }
+
+  // Inline the establishing cascade-layer order into the SSR'd <head> so layer
+  // priority is parsed before any runtime-injected component <style>. Otherwise
+  // injection order decides priority and `vuetify-core.reset` can outrank
+  // component rules (#381). Vuetify 4 only; opt out / customise via cascadeLayers.
+  applyCascadeLayersHeadStyle(nuxt, styles, ctx.moduleOptions.cascadeLayers, ctx.vuetifyGte('4.0.0'))
 
   // transpile always vuetify and runtime folder
   nuxt.options.build.transpile.push(configKey, runtimeDir)

--- a/packages/vuetify-nuxt-module/src/utils/styles.ts
+++ b/packages/vuetify-nuxt-module/src/utils/styles.ts
@@ -1,6 +1,69 @@
 import type { Nuxt } from '@nuxt/schema'
+import type { MOptions } from '../types'
 import { existsSync } from 'node:fs'
 import { isAbsolute, resolve } from 'pathe'
+
+/**
+ * Vuetify 4 ships the establishing cascade-layer order in
+ * `vuetify/lib/styles/generic/_layers.scss`, but in treeshaking modes the
+ * per-component styles are injected on demand by `@vuetify/unplugin-styles` —
+ * each carrying its own `@layer vuetify-components { … }` block. Their DOM
+ * order is decided by injection sequence (non-deterministic in dev, chunk
+ * order in prod), so `vuetify-components` can be declared before `vuetify-core`,
+ * making `vuetify-core.reset` (`button { font: inherit }`) outrank
+ * `.v-btn--size-*`. See #381.
+ *
+ * Flattened to its top-level order, which is all that decides the reported
+ * race (core vs components).
+ */
+const VUETIFY4_CASCADE_LAYERS = '@layer vuetify-core,vuetify-components,vuetify-overrides,vuetify-utilities,vuetify-final;'
+
+/**
+ * Establishing layer-order `<style>` to inline into the SSR'd `<head>` so the
+ * cascade-layer priority is parsed before any runtime-injected component style.
+ *
+ * Vuetify 4 only: v3's layers are opt-in (since 3.8), use different names, and
+ * live under a single top-level `vuetify` layer (no top-level race to fix).
+ * Skipped for `styles: 'none'`/`false`, where the consumer owns the cascade.
+ *
+ * `cascadeLayers` lets a consumer redefine the order — e.g. to slot a custom
+ * layer between Vuetify's — since a flat establishing statement freezes the
+ * named layers contiguously (later-declared new layers can only append). Pass
+ * `false` to opt out and manage the order yourself; omit it for Vuetify's
+ * default order.
+ */
+export function resolveCascadeLayersHeadStyle (
+  styles: MOptions['styles'],
+  cascadeLayers: MOptions['cascadeLayers'],
+  isVuetify4: boolean,
+): { innerHTML: string, tagPriority: number } | undefined {
+  if (!isVuetify4 || styles === 'none' || (styles as unknown) === false || cascadeLayers === false) {
+    return undefined
+  }
+  const innerHTML = Array.isArray(cascadeLayers)
+    ? (cascadeLayers.length > 0 ? `@layer ${cascadeLayers.join(',')};` : undefined)
+    : VUETIFY4_CASCADE_LAYERS
+  return innerHTML === undefined ? undefined : { innerHTML, tagPriority: -100 }
+}
+
+/**
+ * Resolve and append the establishing cascade-layer `<style>` to the SSR'd
+ * `<head>`, if applicable. Thin wrapper over {@link resolveCascadeLayersHeadStyle}
+ * so the decision stays pure and testable while keeping the caller branch-free.
+ */
+export function applyCascadeLayersHeadStyle (
+  nuxt: Nuxt,
+  styles: MOptions['styles'],
+  cascadeLayers: MOptions['cascadeLayers'],
+  isVuetify4: boolean,
+): void {
+  const style = resolveCascadeLayersHeadStyle(styles, cascadeLayers, isVuetify4)
+  if (!style) {
+    return
+  }
+  nuxt.options.app.head.style ??= []
+  nuxt.options.app.head.style.push(style)
+}
 
 export function resolveVuetifyConfigFile (configFile: string, nuxt: Nuxt) {
   if (typeof configFile === 'string' && !isAbsolute(configFile)) {

--- a/packages/vuetify-nuxt-module/test/basic-vuetify3.test.ts
+++ b/packages/vuetify-nuxt-module/test/basic-vuetify3.test.ts
@@ -12,4 +12,9 @@ describe('ssr with vuetify 3', async () => {
     const html = await $fetch('/')
     expect(html).contain('v-application')
   })
+
+  it('does not inline the Vuetify 4 cascade-layer order (#381 — v3 layers differ and are opt-in)', async () => {
+    const html = await $fetch('/')
+    expect(html).not.toContain('@layer vuetify-core')
+  })
 })

--- a/packages/vuetify-nuxt-module/test/cascade-layers-head.test.ts
+++ b/packages/vuetify-nuxt-module/test/cascade-layers-head.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import { resolveCascadeLayersHeadStyle } from '../src/utils/styles'
+
+// The establishing statement Vuetify 4 ships in `generic/_layers.scss`, flattened
+// to its top-level order. Pinning this before any runtime-injected component
+// <style> guarantees `vuetify-components` outranks `vuetify-core.reset`.
+const V4_STATEMENT = '@layer vuetify-core,vuetify-components,vuetify-overrides,vuetify-utilities,vuetify-final;'
+
+describe('resolveCascadeLayersHeadStyle', () => {
+  describe('Vuetify 4 — default order (cascadeLayers undefined)', () => {
+    it('emits the establishing layer order for styles: { configFile }', () => {
+      const style = resolveCascadeLayersHeadStyle({ configFile: 'settings.scss' }, undefined, true)
+      expect(style).toEqual({ innerHTML: V4_STATEMENT, tagPriority: -100 })
+    })
+
+    it('emits it for styles: true', () => {
+      expect(resolveCascadeLayersHeadStyle(true, undefined, true)).toEqual({ innerHTML: V4_STATEMENT, tagPriority: -100 })
+    })
+
+    it('emits it for the default (styles undefined)', () => {
+      expect(resolveCascadeLayersHeadStyle(undefined, undefined, true)).toEqual({ innerHTML: V4_STATEMENT, tagPriority: -100 })
+    })
+
+    it('emits it for object styles without configFile', () => {
+      expect(resolveCascadeLayersHeadStyle({ colors: false, utilities: false }, undefined, true)).toEqual({ innerHTML: V4_STATEMENT, tagPriority: -100 })
+    })
+
+    it('keeps vuetify-core before vuetify-components so the reset cannot win', () => {
+      const style = resolveCascadeLayersHeadStyle(true, undefined, true)!
+      const core = style.innerHTML.indexOf('vuetify-core')
+      const components = style.innerHTML.indexOf('vuetify-components')
+      expect(core).toBeGreaterThanOrEqual(0)
+      expect(core).toBeLessThan(components)
+    })
+  })
+
+  describe('Vuetify 4 — custom order (cascadeLayers array)', () => {
+    it('injects the user-defined order so a layer can sit between Vuetify layers', () => {
+      const order = ['vuetify-core', 'vuetify-components', 'my-overrides', 'vuetify-overrides', 'vuetify-utilities', 'vuetify-final']
+      const style = resolveCascadeLayersHeadStyle(true, order, true)
+      expect(style).toEqual({
+        innerHTML: '@layer vuetify-core,vuetify-components,my-overrides,vuetify-overrides,vuetify-utilities,vuetify-final;',
+        tagPriority: -100,
+      })
+    })
+
+    it('treats an empty array as nothing to establish', () => {
+      expect(resolveCascadeLayersHeadStyle(true, [], true)).toBeUndefined()
+    })
+  })
+
+  describe('opt-out', () => {
+    it('does not emit when cascadeLayers is false', () => {
+      expect(resolveCascadeLayersHeadStyle(true, false, true)).toBeUndefined()
+    })
+
+    it('does not emit when styles is "none" (user owns the cascade)', () => {
+      expect(resolveCascadeLayersHeadStyle('none', undefined, true)).toBeUndefined()
+    })
+
+    it('does not emit when styles is false', () => {
+      expect(resolveCascadeLayersHeadStyle(false as never, undefined, true)).toBeUndefined()
+    })
+
+    it('cascadeLayers: false wins even with a custom-looking styles object', () => {
+      expect(resolveCascadeLayersHeadStyle({ configFile: 'settings.scss' }, false, true)).toBeUndefined()
+    })
+  })
+
+  describe('Vuetify 3 (different, opt-in layers)', () => {
+    it('never emits the v4 statement, even with configFile', () => {
+      expect(resolveCascadeLayersHeadStyle({ configFile: 'settings.scss' }, undefined, false)).toBeUndefined()
+    })
+
+    it('never emits even when a custom order is given', () => {
+      expect(resolveCascadeLayersHeadStyle(true, ['a', 'b'], false)).toBeUndefined()
+    })
+  })
+})

--- a/packages/vuetify-nuxt-module/test/sass.test.ts
+++ b/packages/vuetify-nuxt-module/test/sass.test.ts
@@ -12,4 +12,11 @@ describe('sass', async () => {
     const html = await $fetch('/')
     expect(html).toContain('Hi')
   })
+
+  it('inlines the Vuetify 4 establishing cascade-layer order in the SSR head (#381)', async () => {
+    // Pins layer priority before any runtime-injected component <style>, so the
+    // `vuetify-core.reset` cannot outrank `.v-btn--size-*`.
+    const html = await $fetch('/')
+    expect(html).toContain('@layer vuetify-core,vuetify-components,vuetify-overrides,vuetify-utilities,vuetify-final;')
+  })
 })


### PR DESCRIPTION
## Summary

Fixes #381 — on **Vuetify 4**, `<v-btn size="small">` (and other size/density tokens) intermittently render at the wrong size because the CSS cascade-layer order is non-deterministic.

### Root cause

In styles treeshaking modes, Vuetify 4 component styles are injected on demand by `@vuetify/unplugin-styles`, each carrying its own `@layer vuetify-components { … }` block. Per CSS Cascade 5, layer priority is fixed by the order layer names are **first declared**. With no establishing statement guaranteed to be parsed first, first-declaration = injection order, which is:

- non-deterministic in `nuxt dev` (Vite injects each style module at runtime), and
- chunk-order-dependent in production (visible on hard refresh; SPA nav is fine).

When `vuetify-components` is declared before `vuetify-core`, `vuetify-core.reset` (`button { font: inherit }`) outranks `.v-btn--size-*` → the button renders at the inherited body size.

Vuetify ships the order in `generic/_layers.scss`, but it's just one more racer — and `nuxt.options.css` ordering can't fix it because the racing component styles are injected outside the css graph entirely (the reporter confirmed a `css: ['~/layers.css']` file still raced).

### The fix

Inline the establishing `@layer` statement into the SSR'd `<head>` (`tagPriority: -100`) so it's parsed before any runtime-injected or critical-inlined component style. One mechanism covers dev, prod, SSR and SPA.

```css
@layer vuetify-core,vuetify-components,vuetify-overrides,vuetify-utilities,vuetify-final;
```

**Scope / guards**
- **Vuetify 4 only** — v3's layers are opt-in (since 3.8), differently named, and under a single top-level `vuetify` layer (no top-level race).
- Skipped for `styles: 'none'`.

### New option: `cascadeLayers`

A flat `@layer` statement freezes the named layers contiguously, so a later-declared layer can only append. To keep custom interleaving possible, the injected order is configurable:

```ts
vuetify: {
  moduleOptions: {
    // omit            → Vuetify's default order (the fix, zero config)
    cascadeLayers: [   // custom order — slot your own layer between Vuetify's
      'vuetify-core', 'vuetify-components',
      'my-overrides', 'vuetify-overrides',
      'vuetify-utilities', 'vuetify-final',
    ],
    // cascadeLayers: false  // inject nothing; manage the order yourself
  }
}
```

`VuetifyCascadeLayer` offers the known Vuetify layer names as autocomplete while still allowing arbitrary custom names.

### Upgrade note for existing workarounds

- A **default-order** workaround (e.g. the common inline-head-style snippet) can simply be **removed** — the module now injects the same statement; leaving it is a harmless no-op.
- A **custom-interleaved** order delivered via a `css:`/SCSS file should move to `cascadeLayers` (or set `cascadeLayers: false`), otherwise the default statement parsed first would push the custom layer to the end. Documented in the styling guide.

## Tests

- `test/cascade-layers-head.test.ts` — 13 pure-helper cases (default / custom array / empty / `false` / `'none'` / v3 / core-before-components).
- `test/sass.test.ts` — v4 `configFile` fixture: the SSR head contains the statement.
- `test/basic-vuetify3.test.ts` — v3 fixture: the SSR head does **not** contain it.

Full suite **72 passing**; lint clean on changed source; `prepack` build green with the type shipped into `dist/module.d.mts`.

Closes #381
